### PR TITLE
Add id to shortValue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import {
   BallotStyle,
 } from './config/types'
 
+import { randomBase64 } from './utils/random'
+
 import Button from './components/Button'
 import CurrentVoterCard from './components/CurrentVoterCard'
 import Main, { MainChild } from './components/Main'
@@ -193,7 +195,8 @@ const App = () => {
       setIsProgrammingCard(true)
 
       const createAtSeconds = Math.round(Date.now() / 1000)
-      const code = {
+      const voterCardData: VoterCardData = {
+        id: randomBase64(),
         c: createAtSeconds,
         t: 'voter',
         pr: precinctId,
@@ -201,7 +204,7 @@ const App = () => {
       }
       fetch('/card/write', {
         method: 'post',
-        body: JSON.stringify(code),
+        body: JSON.stringify(voterCardData),
         headers: { 'Content-Type': 'application/json' },
       })
         .then(res => res.json())
@@ -221,7 +224,7 @@ const App = () => {
           window.setTimeout(() => {
             // TODO: UI Notification if unable to write to card
             // https://github.com/votingworks/bas/issues/10
-            console.log(code) // eslint-disable-line no-console
+            console.log(voterCardData) // eslint-disable-line no-console
             reset()
             setIsProgrammingCard(false)
           }, 500)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -99,8 +99,9 @@ export interface CardData {
 export interface VoterCardData extends CardData {
   readonly t: 'voter'
   readonly bs: string
-  readonly pr: string
   readonly c: number
+  readonly id: string
+  readonly pr: string
 }
 export type OptionalVoterCardData = VoterCardData | undefined
 export interface PollworkerCardData extends CardData {

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,12 @@
+export function randomBase64(numBytes: number = 16): string {
+  // get random values to fill an array of prescribed length, b64 encode it, and strip the '=' at the end.
+  return window
+    .btoa(
+      String.fromCharCode.apply(undefined, (window.crypto.getRandomValues(
+        new Uint8ClampedArray(numBytes)
+      ) as unknown) as number[])
+    )
+    .replace(/=+$/, '')
+}
+
+export default { randomBase64 }


### PR DESCRIPTION
Adding this ID will make it much simpler to display a "Cast Your Ballot" screen to the voter after their card has been wiped of votes and marked as used. Instead of relying on calculating times, simply match against the card `id` of the `lastCardId` stored on the app.

This could also be used as the `ballotId` but it would be safer to create a `ballotId` when the `PrintedBallot` component is rendered.